### PR TITLE
ExponeaPushReceiver does not receive broadcast on Android O or higher

### DIFF
--- a/sdk/src/main/java/com/exponea/sdk/services/ExponeaPushReceiver.kt
+++ b/sdk/src/main/java/com/exponea/sdk/services/ExponeaPushReceiver.kt
@@ -17,6 +17,7 @@ class ExponeaPushReceiver : BroadcastReceiver() {
         fun getClickIntent(context: Context, data: NotificationData) : Intent {
             return Intent(ACTION_CLICKED).apply {
                 putExtra(EXTRA_DATA, data)
+                `package` = context.packageName
             }
         }
     }


### PR DESCRIPTION
_**What's this PR about?**_
**Backstory**: 
Push notifications - Tracking when a push notification is clicked

**Problem**:
The notification clicked event is not being tracked on Android O or higher

**Verdict**:
ExponeaPushReceiver does not receive broadcasts  on Android O or higher. For security reasons, Android changed how broadcast receivers worked on Android 8.0 (https://developer.android.com/guide/components/broadcasts#context-registered-recievers). The broadcast we are creating now is implicit, we need to make it explicit.

**Resolution**:
Add the package of the context to the intent for ACTION_CLICKED, so the broadcast is explicit instead of implicit (https://stackoverflow.com/questions/46121467/differentiate-implicit-broadcast-receiver-vs-explicit-broadcast-receiver-in-the)