### PR TITLE
Improvement/pass notification information to broadcast receiver

### DIFF
--- a/sdk/src/main/java/com/exponea/sdk/manager/FcmManager.kt
+++ b/sdk/src/main/java/com/exponea/sdk/manager/FcmManager.kt
@@ -4,6 +4,6 @@ import android.app.NotificationManager
 import com.exponea.sdk.models.NotificationData
 
 interface FcmManager {
-    fun showNotification(title: String, message: String, data: NotificationData, id: Int, manager: NotificationManager)
+    fun showNotification(title: String, message: String, data: NotificationData, id: Int, manager: NotificationManager, messageData: HashMap<String, String>)
     fun createNotificationChannel(manager: NotificationManager)
 }

--- a/sdk/src/main/java/com/exponea/sdk/manager/FcmManagerImpl.kt
+++ b/sdk/src/main/java/com/exponea/sdk/manager/FcmManagerImpl.kt
@@ -25,11 +25,12 @@ class FcmManagerImpl(
             message: String,
             data: NotificationData,
             id: Int,
-            manager: NotificationManager
+            manager: NotificationManager,
+            messageData: HashMap<String, String>
     ) {
         Logger.d(this, "showNotification")
 
-        val i = ExponeaPushReceiver.getClickIntent(context, id, data)
+        val i = ExponeaPushReceiver.getClickIntent(context, id, data, messageData)
 
         val pendingIntent = PendingIntent.getBroadcast(
                 context, requestCode,

--- a/sdk/src/main/java/com/exponea/sdk/manager/FcmManagerImpl.kt
+++ b/sdk/src/main/java/com/exponea/sdk/manager/FcmManagerImpl.kt
@@ -29,7 +29,7 @@ class FcmManagerImpl(
     ) {
         Logger.d(this, "showNotification")
 
-        val i = ExponeaPushReceiver.getClickIntent(context, data)
+        val i = ExponeaPushReceiver.getClickIntent(context, id, data)
 
         val pendingIntent = PendingIntent.getBroadcast(
                 context, requestCode,

--- a/sdk/src/main/java/com/exponea/sdk/services/ExponeaFirebaseMessageService.kt
+++ b/sdk/src/main/java/com/exponea/sdk/services/ExponeaFirebaseMessageService.kt
@@ -56,13 +56,24 @@ class ExponeaFirebaseMessageService : FirebaseMessagingService() {
                 data = data
         )
 
+        //Create a map with all the data of the remote message, removing the data already processed
+        val messageData = message?.data?.apply {
+            remove("title")
+            remove("message")
+            remove("data")
+            remove("notification_id")
+        }?.run {
+            HashMap(this)
+        } ?: HashMap()
+
         // Show push notification.
         Exponea.component.fcmManager.showNotification(
                 title,
                 body,
                 data,
                 notificationId,
-                notificationManager
+                notificationManager,
+                messageData
         )
     }
 }

--- a/sdk/src/main/java/com/exponea/sdk/services/ExponeaPushReceiver.kt
+++ b/sdk/src/main/java/com/exponea/sdk/services/ExponeaPushReceiver.kt
@@ -14,14 +14,17 @@ class ExponeaPushReceiver : BroadcastReceiver() {
         const val ACTION_CLICKED = "com.exponea.sdk.action.PUSH_CLICKED"
         const val EXTRA_NOTIFICATION_ID = "NotificationId"
         const val EXTRA_DATA = "NotificationData"
+        const val EXTRA_CUSTOM_DATA = "NotificationCustomData"
 
         fun getClickIntent(
                 context: Context,
                 id: Int,
-                data: NotificationData) : Intent {
+                data: NotificationData,
+                messageData : HashMap<String, String>) : Intent {
             return Intent(ACTION_CLICKED).apply {
                 putExtra(EXTRA_NOTIFICATION_ID, id)
                 putExtra(EXTRA_DATA, data)
+                putExtra(EXTRA_CUSTOM_DATA, messageData)
             }
         }
     }

--- a/sdk/src/main/java/com/exponea/sdk/services/ExponeaPushReceiver.kt
+++ b/sdk/src/main/java/com/exponea/sdk/services/ExponeaPushReceiver.kt
@@ -12,10 +12,15 @@ class ExponeaPushReceiver : BroadcastReceiver() {
 
     companion object {
         const val ACTION_CLICKED = "com.exponea.sdk.action.PUSH_CLICKED"
+        const val EXTRA_NOTIFICATION_ID = "NotificationId"
         const val EXTRA_DATA = "NotificationData"
 
-        fun getClickIntent(context: Context, data: NotificationData) : Intent {
+        fun getClickIntent(
+                context: Context,
+                id: Int,
+                data: NotificationData) : Intent {
             return Intent(ACTION_CLICKED).apply {
+                putExtra(EXTRA_NOTIFICATION_ID, id)
                 putExtra(EXTRA_DATA, data)
             }
         }


### PR DESCRIPTION
_**What's this PR about?**_
**Backstory**: 
Notifications management and custom information

**Problem**:
As the SDK is now, there is no way for a external receiver listening for notification clicked broadcasts to know the id of the clicked notification or to get the information received in the push message. The id is required in order to manage the notification via notification manager (i.e., close the notification). The information received is required in case some extra data has been added to the payload for a specific custom (i.e., a deep link)

**Verdict**:
We only have to add the information to the intent used for the broadcast, so a custom receiver can extract the required data.

**Resolution**:
- Add the notification id to the broadcast intent
- Pass a map with the custom information received on the remote message to the fcm manager
- Add a map with the custom information received on the remote message to the broadcast intent

**Alternative resolution**
The proposed solution creates a HashMap from the data of the remote message, removing the already processed information: title, message, notification id and data (NotificationData). This HashMap is then passed to the FCMManager and then to the intent of the broadcast.
It would be possible to simplify this (and reduce the number of changes required) by simply passing the data from the RemoteMessage as it is (Map<String,String>) and creating the required HashMap in the method to get the intent for the broadcast (putExtra requires a HashMap or any serializable/parcelable implementation)