### PR TITLE
Enable setting HTTP logging level

### DIFF
--- a/app/src/main/java/com/exponea/example/view/AuthenticationActivity.kt
+++ b/app/src/main/java/com/exponea/example/view/AuthenticationActivity.kt
@@ -69,6 +69,7 @@ class AuthenticationActivity : AppCompatActivity() {
         configuration.authorization = authorizationToken
         configuration.projectToken = projectToken
         configuration.baseURL = apiUrl
+        configuration.httpLoggingLevel = ExponeaConfiguration.HttpLoggingLevel.BODY
 
         // Set our customer registration id
         if (editTextRegisteredIds.isValid()) {

--- a/sdk/src/main/java/com/exponea/sdk/models/ExponeaConfiguration.kt
+++ b/sdk/src/main/java/com/exponea/sdk/models/ExponeaConfiguration.kt
@@ -11,6 +11,8 @@ data class ExponeaConfiguration(
         var authorization: String? = null,
         /** Base url for http requests to Exponea API. */
         var baseURL: String = Constants.Repository.baseURL,
+        /** Level of HTTP logging, default value is BODY. */
+        var httpLoggingLevel: HttpLoggingLevel = HttpLoggingLevel.BODY,
         /** Content type value to make http requests. */
         var contentType: String = Constants.Repository.contentType,
         /** Maximum retries value to flush data to api. */
@@ -34,4 +36,14 @@ data class ExponeaConfiguration(
         /** Notification importance for the notification channel. Only for API level 26+. */
         var pushNotificationImportance: Int = NotificationManager.IMPORTANCE_DEFAULT
 ) {
+    enum class HttpLoggingLevel {
+        /** No logs. */
+        NONE,
+        /** Logs request and response lines. */
+        BASIC,
+        /** Logs request and response lines and their respective headers. */
+        HEADERS,
+        /** Logs request and response lines and their respective headers and bodies (if present). */
+        BODY
+    }
 }

--- a/sdk/src/main/java/com/exponea/sdk/models/ExponeaConfiguration.kt
+++ b/sdk/src/main/java/com/exponea/sdk/models/ExponeaConfiguration.kt
@@ -3,35 +3,35 @@ package com.exponea.sdk.models
 import android.app.NotificationManager
 
 data class ExponeaConfiguration(
-        // Default project token.
+        /** Default project token. */
         var projectToken: String = "",
-        // Map event types and project tokens to be send to Exponea API.
+        /** Map event types and project tokens to be send to Exponea API. */
         var projectTokenRouteMap: HashMap<EventType, MutableList<String>> = hashMapOf(),
-        // Authorization http header.
+        /** Authorization http header. */
         var authorization: String? = null,
-        // Base url for http requests to Exponea API.
+        /** Base url for http requests to Exponea API. */
         var baseURL: String = Constants.Repository.baseURL,
-        // Content type value to make http requests.
+        /** Content type value to make http requests. */
         var contentType: String = Constants.Repository.contentType,
-        // Maximum retries value to flush data to api.
+        /** Maximum retries value to flush data to api. */
         var maxTries: Int = 10,
-        // Timeout session value considered for app usage.
+        /** Timeout session value considered for app usage. */
         var sessionTimeout: Double = 20.0,
-        // Flag to control automatic tracking for In-App purchases
+        /** Flag to control automatic tracking for In-App purchases */
         var automaticPaymentTracking: Boolean = true,
-        // Flag to control automatic session tracking
+        /** Flag to control automatic session tracking */
         var automaticSessionTracking: Boolean = true,
-        // Flag to control if the App will handle push notifications automatically.
+        /** Flag to control if the App will handle push notifications automatically. */
         var automaticPushNotification: Boolean = true,
-        // Icon to be showed in push notifications.
+        /** Icon to be showed in push notifications. */
         var pushIcon: Int? = null,
-        // Channel name for push notifications. Only for API level 26+.
+        /** Channel name for push notifications. Only for API level 26+. */
         var pushChannelName: String = "Exponea",
-        // Channel description for push notifications. Only for API level 26+.
+        /** Channel description for push notifications. Only for API level 26+. */
         var pushChannelDescription: String = "Notifications",
-        // Channel ID for push notifications. Only for API level 26+.
+        /** Channel ID for push notifications. Only for API level 26+. */
         var pushChannelId: String = "0",
-        // Notification importance for the notification channel. Only for API level 26+.
+        /** Notification importance for the notification channel. Only for API level 26+. */
         var pushNotificationImportance: Int = NotificationManager.IMPORTANCE_DEFAULT
 ) {
 }

--- a/sdk/src/main/java/com/exponea/sdk/network/NetworkHandlerImpl.kt
+++ b/sdk/src/main/java/com/exponea/sdk/network/NetworkHandlerImpl.kt
@@ -51,7 +51,12 @@ class NetworkHandlerImpl(private var exponeaConfiguration: ExponeaConfiguration)
     private fun getNetworkLogger(): HttpLoggingInterceptor {
         val interceptor = HttpLoggingInterceptor()
 
-        interceptor.level = HttpLoggingInterceptor.Level.BODY
+        interceptor.level = when(exponeaConfiguration.httpLoggingLevel) {
+            ExponeaConfiguration.HttpLoggingLevel.NONE -> HttpLoggingInterceptor.Level.NONE
+            ExponeaConfiguration.HttpLoggingLevel.BASIC -> HttpLoggingInterceptor.Level.BASIC
+            ExponeaConfiguration.HttpLoggingLevel.HEADERS -> HttpLoggingInterceptor.Level.HEADERS
+            ExponeaConfiguration.HttpLoggingLevel.BODY -> HttpLoggingInterceptor.Level.BODY
+        }
 
         return interceptor
     }


### PR DESCRIPTION
The default logging level is too verbose:

```
2019-01-07 13:24:08.503 4769-5414/com.skypicker.main.debug D/OkHttp: <-- 200 https://skypicker-api.infinario.com/track/v2/projects/xxx/customers/events (51ms)
2019-01-07 13:24:08.503 4769-5414/com.skypicker.main.debug D/OkHttp: server: nginx/1.7.9
2019-01-07 13:24:08.503 4769-5414/com.skypicker.main.debug D/OkHttp: date: Mon, 07 Jan 2019 12:24:09 GMT
2019-01-07 13:24:08.503 4769-5414/com.skypicker.main.debug D/OkHttp: content-type: application/json
2019-01-07 13:24:08.503 4769-5414/com.skypicker.main.debug D/OkHttp: content-length: 37
2019-01-07 13:24:08.503 4769-5414/com.skypicker.main.debug D/OkHttp: access-control-allow-origin: *
2019-01-07 13:24:08.503 4769-5414/com.skypicker.main.debug D/OkHttp: access-control-allow-headers: content-type
2019-01-07 13:24:08.503 4769-5414/com.skypicker.main.debug D/OkHttp: access-control-allow-credentials: true
2019-01-07 13:24:08.503 4769-5414/com.skypicker.main.debug D/OkHttp: via: 1.1 google
2019-01-07 13:24:08.503 4769-5414/com.skypicker.main.debug D/OkHttp: alt-svc: clear
2019-01-07 13:24:08.505 4769-5414/com.skypicker.main.debug D/OkHttp: {
2019-01-07 13:24:08.505 4769-5414/com.skypicker.main.debug D/OkHttp:   "errors": [],
2019-01-07 13:24:08.505 4769-5414/com.skypicker.main.debug D/OkHttp:   "success": true
2019-01-07 13:24:08.505 4769-5414/com.skypicker.main.debug D/OkHttp: }
2019-01-07 13:24:08.505 4769-5414/com.skypicker.main.debug D/OkHttp: <-- END HTTP (37-byte body)
```