### PR TITLE
Jailbreak from jCenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,6 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
         mavenCentral()
         maven {
             url "https://plugins.gradle.org/m2/"
@@ -26,7 +25,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
     }
 }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -42,7 +42,7 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     // Database
-    implementation 'io.paperdb:paperdb:2.7.1'
+    implementation 'io.github.pilgr:paperdb:2.7.1'
     // Networking
     implementation 'com.squareup.okhttp3:okhttp:3.12.1'
     // Deserialization


### PR DESCRIPTION
Hello. Thank You for Your product. It is very useful for Us!
As You know jCenter is deprecated now (https://developer.android.com/studio/build/jcenter-migration)
But I cant migrate without changes on your side. It is easy. You should upgrade **paperdb** dependency. I prepare the MR for it.
Without this changes I got a error from Gradle:
   
> Could not resolve all files for configuration ':app:debugRuntimeClasspath'.
   > Could not find io.paperdb:paperdb:2.7.1.
     Searched in the following locations:
       - https://repo.maven.apache.org/maven2/io/paperdb/paperdb/2.7.1/paperdb-2.7.1.pom
       - https://jitpack.io/io/paperdb/paperdb/2.7.1/paperdb-2.7.1.pom
       - https://dl.google.com/dl/android/maven2/io/paperdb/paperdb/2.7.1/paperdb-2.7.1.pom
       - https://www.myget.org/F/abtsoftware/maven/io/paperdb/paperdb/2.7.1/paperdb-2.7.1.pom
     Required by:
         project :app > com.exponea.sdk:sdk:2.9.5

I have a workaround but I hope You will accept the changes.
My workaround :

```
    implementation ('com.exponea.sdk:sdk:2.9.5') {
        exclude group: "io.paperdb", module: "paperdb"
    }
    implementation 'io.github.pilgr:paperdb:2.7.1'
```
